### PR TITLE
Allow for DUT Target to clock stretch

### DIFF
--- a/cocotbext/i2c/i2c_master.py
+++ b/cocotbext/i2c/i2c_master.py
@@ -123,10 +123,10 @@ class I2cMaster:
 
         self._set_sda(1)
         await self._half_bit_t
-        b = bool(int(self.sda.value))
         self._set_scl(1)
         while not int(self.scl.value):
             await RisingEdge(self.scl)
+        b = bool(int(self.sda.value))
         await self._bit_t
         self._set_scl(0)
         await self._half_bit_t


### PR DESCRIPTION
When an I2C target of the DUT is clock stretching, the I2C controller in this library samples SDA at the wrong time (well before the clock stretching is coplete. When this happens, the wrong read data is captured. The read data needs to be captured after the rising edge of SCL.
<img width="1098" height="194" alt="image" src="https://github.com/user-attachments/assets/42297c28-c024-4d8b-a599-acff8cee6c47" />
